### PR TITLE
Add H2 in-memory database functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ matrix:
       before_script: 
         - cd server
       script:
-        - ./mvnw install -DskipTests
+        - ./mvnw install
         - ./mvnw compile

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -31,5 +31,4 @@ build/
 
 ### VS Code ###
 .vscode/
-application.properties
 application-dev.properties

--- a/server/README.md
+++ b/server/README.md
@@ -24,13 +24,21 @@ All variables must be defined and valid for the server to function.
 Alternatively an *application-dev.properties* file can be created within the [resources](src/main/resources) directory.
 
 This file will be ignored by git so credentials can be placed within it directly. 
-Appending 
+Prepending
 ```console
--Dspring.profiles.active=dev
+SPRING_PROFILES_ACTIVE=dev
 ``` 
 to mvnw commands will use the properties defined in 'application-dev.properties' 
 
-### Project Setup
+### Using the in-memory database
+A profile to run the server with an H2 in-memory database is included.
+Prepending
+```console
+SPRING_PROFILES_ACTIVE=h2
+``` 
+to mvnw commands will use the properties defined in 'application-h2.properties' 
+
+## Project Setup
 ```console
 $ git clone https://github.com/malinoskj2/JOLO-Web-Test
 
@@ -43,7 +51,7 @@ $ ./mvnw install
 $ mvnw.cmd install
 ```
 
-### Run Development Server
+## Run Development Server
 ```console
 # linux, mac os x
 $ ./mvnw spring-boot:run
@@ -52,7 +60,7 @@ $ ./mvnw spring-boot:run
 $ mvnw.cmd spring-boot:run
 ```
 
-### Build
+## Build
 ```console
 # linux, mac os x
 $ ./mvnw compile

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -52,6 +52,16 @@
             <scope>runtime</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.4.194</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-entitymanager</artifactId>
+            <version>5.2.9.Final</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/server/src/main/resources/application-h2.properties
+++ b/server/src/main/resources/application-h2.properties
@@ -1,0 +1,21 @@
+# Server
+server.port=8081
+
+# Database
+jdbc.driverClassName=org.h2.Driver
+# jdbc.url=jdbc:h2:mem:myDb;DB_CLOSE_DELAY=-1
+spring.datasource.url=jdbc:h2:mem:myDb;DB_CLOSE_DELAY=-1
+hibernate.dialect=org.hibernate.dialect.H2Dialect
+hibernate.hbm2ddl.auto=create
+
+# Misc
+spring.jackson.time-zone=America/New_York
+spring.main.banner-mode=off
+
+#Logging
+logging.pattern.console=%clr(%-5p): %msg%n
+logging.level.root=WARN
+logging.level.org.springframework.web=INFO
+logging.level.org.hibernate=ERROR
+logging.level.server=INFO
+logging.file.name=/var/log/jolo.log

--- a/server/src/test/resources/application.properties
+++ b/server/src/test/resources/application.properties
@@ -1,0 +1,20 @@
+# Server
+server.port=8081
+
+# Database
+jdbc.driverClassName=org.h2.Driver
+jdbc.url=jdbc:h2:mem:myDb;DB_CLOSE_DELAY=-1
+hibernate.dialect=org.hibernate.dialect.H2Dialect
+hibernate.hbm2ddl.auto=create
+
+# Misc
+spring.jackson.time-zone=America/New_York
+spring.main.banner-mode=off
+
+#Logging
+logging.pattern.console=%clr(%-5p): %msg%n
+logging.level.root=WARN
+logging.level.org.springframework.web=INFO
+logging.level.org.hibernate=ERROR
+logging.level.server=INFO
+logging.file.name=/var/log/jolo.log


### PR DESCRIPTION
With this pr by default all tests will run on the H2 in-memory database. This makes using J-Unit to test endpoints super convenient.

The application itself can also run on H2 with the command:
`SPRING_PROFILES_ACTIVE=h2 ./mvnw spring-boot:run`

